### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- configure Dependabot to check GitHub Actions and Python packages weekly using uv

## Testing
- `uv run pre-commit run --files .github/dependabot.yml` *(fails: version `3.13.6` is not installed)*
- `make test` *(fails: version `3.13.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689a1b3bcabc83318bf53025d1c9821d