### PR TITLE
feat: add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 uv run python -m app.main
 ```
 
+### Logging
+
+The bot uses Python's standard `logging` module. Logs are emitted at the
+`INFO` level by default with timestamps, logger names and messages. Adjust the
+log level via environment variables or in `main.py` if needed.
+
 ### Deploy to Fly
 
 1) Create Postgres/Redis apps (optional), set secrets on bot:

--- a/src/buddy_gym_bot/db.py
+++ b/src/buddy_gym_bot/db.py
@@ -1,11 +1,18 @@
+"""Database connection helpers."""
+
+import logging
 from contextlib import asynccontextmanager
 
 import psycopg
 
 from .settings import settings
 
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def get_conn():
+    logger.debug("Opening database connection")
     async with await psycopg.AsyncConnection.connect(settings.DATABASE_URL) as conn:
+        logger.debug("Database connection established")
         yield conn

--- a/src/buddy_gym_bot/handlers/ask.py
+++ b/src/buddy_gym_bot/handlers/ask.py
@@ -1,10 +1,15 @@
-# src/buddy_gym_bot/handlers/ask.py
+"""Handler for the /ask command."""
+
+import logging
+
 from aiogram import Router
 from aiogram.types import Message
 from openai import OpenAI
 
 router = Router()
 client = OpenAI()  # reads OPENAI_API_KEY from env
+
+logger = logging.getLogger(__name__)
 
 SYS: str = (
     "You are a concise, evidence-informed strength coach. "
@@ -19,8 +24,10 @@ async def ask(msg: Message) -> None:
     text: str = msg.text or ""
     query: str = text[len("/ask") :].strip()
     if not query:
+        logger.debug("Empty /ask query from %s", getattr(msg.from_user, "id", "unknown"))
         await msg.reply("Usage: /ask Best warm-up for squats?")
         return
+    logger.info("/ask from %s: %s", getattr(msg.from_user, "id", "unknown"), query)
 
     try:
         resp = client.chat.completions.create(
@@ -37,5 +44,5 @@ async def ask(msg: Message) -> None:
             content = str(content)
         await msg.reply(content.strip())
     except Exception:
-        # Keep it user-friendly; log details in real apps
+        logger.exception("Failed to answer /ask")
         await msg.reply("Sorry, I couldn't answer that right now. Please try again in a bit.")

--- a/src/buddy_gym_bot/handlers/log.py
+++ b/src/buddy_gym_bot/handlers/log.py
@@ -1,6 +1,7 @@
 # src/buddy_gym_bot/handlers/log.py
 from __future__ import annotations
 
+import logging
 import re
 
 from aiogram import Router
@@ -9,6 +10,8 @@ from aiogram.types import Message
 from buddy_gym_bot.db import get_conn
 
 router = Router()
+
+logger = logging.getLogger(__name__)
 
 # /log Bench 3x5 @ 60kg RPE7
 PAT = re.compile(
@@ -23,6 +26,7 @@ async def log(msg: Message) -> None:
     text: str = msg.text or ""
     m = PAT.search(text)
     if not m:
+        logger.debug("Failed to parse log command: %s", text)
         await msg.reply("Format: /log Bench 3x5 @ 60kg RPE7")
         return
 
@@ -53,6 +57,16 @@ async def log(msg: Message) -> None:
             (uid, exercise, sets_i, reps_i, weight_f, rpe_f),
         )
 
+    logger.info(
+        "Logged set for user %s: %s %sx%s @ %s%s RPE%s",
+        uid,
+        exercise,
+        sets_i,
+        reps_i,
+        weight_f,
+        unit_disp,
+        rpe_f,
+    )
     await msg.reply(
         f"✅ Logged: {exercise} {sets_i}x{reps_i} @ {weight_f:g}{unit_disp} RPE{rpe_f:g}"
     )

--- a/src/buddy_gym_bot/handlers/plan.py
+++ b/src/buddy_gym_bot/handlers/plan.py
@@ -1,3 +1,6 @@
+"""Handler for the /plan command."""
+
+import logging
 from datetime import date
 
 from aiogram import F, Router
@@ -8,6 +11,8 @@ from ..planner import UserProfile, make_week_plan
 
 router = Router()
 
+logger = logging.getLogger(__name__)
+
 
 @router.message(F.text.startswith("/plan"))
 async def plan(msg: Message):
@@ -17,6 +22,13 @@ async def plan(msg: Message):
     equip = parts[3] if len(parts) > 3 else "gym"
     profile = UserProfile(goal=goal, experience="novice", days_per_week=days, equipment=equip)
     week = make_week_plan(profile)
+    logger.info(
+        "Generated plan for user %s: goal=%s days=%s equip=%s",
+        getattr(msg.from_user, "id", "unknown"),
+        goal,
+        days,
+        equip,
+    )
 
     async with get_conn() as conn:
         await conn.execute(

--- a/src/buddy_gym_bot/handlers/start.py
+++ b/src/buddy_gym_bot/handlers/start.py
@@ -1,9 +1,15 @@
+"""Handler for the /start command."""
+
+import logging
+
 from aiogram import F, Router
 from aiogram.types import Message
 
 from ..db import get_conn
 
 router = Router()
+
+logger = logging.getLogger(__name__)
 
 
 @router.message(F.text.startswith("/start"))
@@ -13,6 +19,7 @@ async def start(msg: Message):
             "insert into users (tg_user_id) values (%s) on conflict (tg_user_id) do nothing",
             (msg.from_user.id,),
         )
+    logger.info("User %s started bot", getattr(msg.from_user, "id", "unknown"))
     await msg.answer(
         "🏋️ Welcome! I'm your gym buddy.\n"
         "• Set up: /plan\n"

--- a/src/buddy_gym_bot/handlers/stats.py
+++ b/src/buddy_gym_bot/handlers/stats.py
@@ -1,9 +1,15 @@
+"""Handler for the /stats command."""
+
+import logging
+
 from aiogram import Router
 from aiogram.types import Message
 
 from ..db import get_conn
 
 router = Router()
+
+logger = logging.getLogger(__name__)
 
 
 @router.message(lambda m: m.text and m.text.startswith("/stats"))
@@ -14,6 +20,7 @@ async def stats(msg: Message):
             (msg.from_user.id,),
         )
         rows = await cur.fetchall()
+    logger.info("Stats requested by user %s", getattr(msg.from_user, "id", "unknown"))
     if not rows:
         return await msg.reply("No stats yet. Log a set with /log")
     lines = [f"• {e}: PR {w:g}" for e, w in rows]

--- a/src/buddy_gym_bot/handlers/today.py
+++ b/src/buddy_gym_bot/handlers/today.py
@@ -1,3 +1,6 @@
+"""Handler for the /today command."""
+
+import logging
 from datetime import date
 
 from aiogram import Router
@@ -6,6 +9,8 @@ from aiogram.types import Message
 from ..db import get_conn
 
 router = Router()
+
+logger = logging.getLogger(__name__)
 
 
 @router.message(lambda m: m.text and m.text.startswith("/today"))
@@ -17,6 +22,7 @@ async def today(msg: Message):
             (msg.from_user.id, dow, date.today()),
         )
         rec = await cur.fetchone()
+    logger.info("Today's workout requested by user %s", getattr(msg.from_user, "id", "unknown"))
     if not rec:
         return await msg.reply("No plan for today. Run /plan first.")
     plan = rec[0]

--- a/src/buddy_gym_bot/main.py
+++ b/src/buddy_gym_bot/main.py
@@ -1,5 +1,7 @@
-# src/buddy_gym_bot/main.py
+"""Application entry point and bot setup."""
+
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import cast
 
@@ -17,6 +19,13 @@ from buddy_gym_bot.handlers.stats import router as r_stats
 from buddy_gym_bot.handlers.today import router as r_today
 from buddy_gym_bot.settings import settings
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
 
 async def main() -> None:
     bot = Bot(
@@ -29,6 +38,7 @@ async def main() -> None:
         dp.include_router(r)
 
     if settings.USE_WEBHOOK:
+        logger.info("Starting in webhook mode")
         app = web.Application()
 
         async def healthz(_: web.Request) -> web.Response:
@@ -54,6 +64,7 @@ async def main() -> None:
         setup_application(app, dp, bot=bot)
         web.run_app(app, host="0.0.0.0", port=8080)
     else:
+        logger.info("Starting in polling mode")
         await bot.delete_webhook(drop_pending_updates=True)
         await dp.start_polling(bot)
 

--- a/src/buddy_gym_bot/planner.py
+++ b/src/buddy_gym_bot/planner.py
@@ -1,4 +1,10 @@
+"""Simple training plan generator."""
+
+import logging
 from dataclasses import dataclass
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -20,6 +26,7 @@ FULL_BODY = [
 
 
 def make_week_plan(u: UserProfile) -> list[list[dict]]:
+    logger.debug("Making week plan: %s", u)
     days = max(3, min(6, u.days_per_week or 3))
     week: list[list[dict]] = []
     for d in range(days):
@@ -27,4 +34,5 @@ def make_week_plan(u: UserProfile) -> list[list[dict]]:
         if d % 2 == 1:
             day = day[1:] + day[:1]
         week.append(day)
+    logger.debug("Generated week plan with %s days", days)
     return week

--- a/src/buddy_gym_bot/progression.py
+++ b/src/buddy_gym_bot/progression.py
@@ -1,4 +1,17 @@
+"""Progression logic for training loads."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def next_load(current_weight: float | None, success: bool, rep_goal: int) -> float:
+    logger.debug(
+        "Calculating next load: current=%s success=%s rep_goal=%s",
+        current_weight,
+        success,
+        rep_goal,
+    )
     if current_weight is None:
         return 20.0
     if success:
@@ -8,4 +21,5 @@ def next_load(current_weight: float | None, success: bool, rep_goal: int) -> flo
 
 
 def should_deload(fails_in_row: int) -> bool:
+    logger.debug("Checking deload: fails_in_row=%s", fails_in_row)
     return fails_in_row >= 2


### PR DESCRIPTION
## Summary
- configure central logging and startup messages in main entrypoint
- add per-module loggers for commands, planning, DB access, and progression logic
- document default logging behaviour in README

## Testing
- `pre-commit run --files README.md src/buddy_gym_bot/db.py src/buddy_gym_bot/handlers/ask.py src/buddy_gym_bot/handlers/log.py src/buddy_gym_bot/handlers/plan.py src/buddy_gym_bot/handlers/start.py src/buddy_gym_bot/handlers/stats.py src/buddy_gym_bot/handlers/today.py src/buddy_gym_bot/main.py src/buddy_gym_bot/planner.py src/buddy_gym_bot/progression.py` *(fails: Failed to inspect Python interpreter / pyenv missing 3.13.6)*
- `.venv/bin/pip install pre-commit` *(fails: could not find a version via proxy)*
- `python3 -m pytest` *(fails: No module named pytest)*
- `.venv/bin/pip install pytest` *(fails: could not find a version via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689a228ca12c83319fe378e58621502e