### PR TITLE
Use week start Monday for plans

### DIFF
--- a/src/buddy_gym_bot/handlers/plan.py
+++ b/src/buddy_gym_bot/handlers/plan.py
@@ -1,7 +1,7 @@
 """Handler for the /plan command."""
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 from aiogram import F, Router
 from aiogram.types import Message
@@ -30,14 +30,17 @@ async def plan(msg: Message):
         equip,
     )
 
+    today = date.today()
+    week_start = today - timedelta(days=today.weekday())
+
     async with get_conn() as conn:
         await conn.execute(
             "delete from workouts where tg_user_id=%s and week_start=%s",
-            (msg.from_user.id, date.today()),
+            (msg.from_user.id, week_start),
         )
         for idx, _day in enumerate(week, start=1):
             await conn.execute(
                 "insert into workouts (tg_user_id, day_of_week, plan, week_start) values (%s,%s,%s,%s)",
-                (msg.from_user.id, idx, week[idx - 1], date.today()),
+                (msg.from_user.id, idx, week[idx - 1], week_start),
             )
     await msg.reply(f"✅ Plan created for {days} days/week ({goal}, {equip}). Use /today.")

--- a/src/buddy_gym_bot/handlers/today.py
+++ b/src/buddy_gym_bot/handlers/today.py
@@ -1,7 +1,7 @@
 """Handler for the /today command."""
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 from aiogram import Router
 from aiogram.types import Message
@@ -15,11 +15,13 @@ logger = logging.getLogger(__name__)
 
 @router.message(lambda m: m.text and m.text.startswith("/today"))
 async def today(msg: Message):
-    dow = date.today().isoweekday()
+    today = date.today()
+    dow = today.isoweekday()
+    week_start = today - timedelta(days=today.weekday())
     async with get_conn() as conn:
         cur = await conn.execute(
             "select plan from workouts where tg_user_id=%s and day_of_week=%s and week_start=%s",
-            (msg.from_user.id, dow, date.today()),
+            (msg.from_user.id, dow, week_start),
         )
         rec = await cur.fetchone()
     logger.info("Today's workout requested by user %s", getattr(msg.from_user, "id", "unknown"))

--- a/tests/test_today_handler.py
+++ b/tests/test_today_handler.py
@@ -1,0 +1,95 @@
+"""Regression tests for the /today handler."""
+
+from __future__ import annotations
+
+import types
+from contextlib import asynccontextmanager
+from datetime import date
+
+import pytest
+
+from buddy_gym_bot.handlers import plan as plan_module
+from buddy_gym_bot.handlers import today as today_module
+
+
+class DummyMessage:
+    """Minimal Telegram message stub for handlers."""
+
+    def __init__(self, text: str, user_id: int = 1) -> None:
+        self.text = text
+        self.from_user = types.SimpleNamespace(id=user_id)
+        self.replies: list[str] = []
+
+    async def reply(self, text: str, **_: object) -> None:  # pragma: no cover - params unused
+        self.replies.append(text)
+
+
+class FakeCursor:
+    def __init__(self, plan: list[dict] | None) -> None:
+        self._plan = plan
+
+    async def fetchone(self) -> list[dict] | None:
+        return (self._plan,) if self._plan is not None else None
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.storage: dict[tuple[int, int, date], list[dict]] = {}
+
+    async def execute(self, sql: str, params: tuple) -> FakeCursor | None:  # noqa: ANN401
+        if sql.startswith("delete from workouts"):
+            tg_user_id, week_start = params
+            keys = [k for k in self.storage if k[0] == tg_user_id and k[2] == week_start]
+            for k in keys:
+                del self.storage[k]
+            return None
+        if sql.startswith("insert into workouts"):
+            tg_user_id, day_of_week, plan, week_start = params
+            self.storage[(tg_user_id, day_of_week, week_start)] = plan
+            return None
+        if sql.startswith("select plan from workouts"):
+            tg_user_id, day_of_week, week_start = params
+            plan = self.storage.get((tg_user_id, day_of_week, week_start))
+            return FakeCursor(plan)
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+
+def test_today_after_plan_same_week(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/today should return a workout later in the same week as /plan."""
+
+    fake_conn = FakeConn()
+
+    @asynccontextmanager
+    async def fake_get_conn():  # pragma: no cover - helper
+        yield fake_conn
+
+    monkeypatch.setattr(plan_module, "get_conn", fake_get_conn)
+    monkeypatch.setattr(today_module, "get_conn", fake_get_conn)
+
+    class FakeDate(date):
+        _today = date(2024, 1, 1)  # Monday
+
+        @classmethod
+        def today(cls) -> "FakeDate":
+            return cls._today
+
+    monkeypatch.setattr(plan_module, "date", FakeDate)
+    monkeypatch.setattr(today_module, "date", FakeDate)
+
+    async def run() -> None:
+        # Create plan on Monday
+        plan_msg = DummyMessage("/plan")
+        await plan_module.plan(plan_msg)
+
+        # Request today's workout on Wednesday of the same week
+        FakeDate._today = date(2024, 1, 3)
+        today_msg = DummyMessage("/today")
+        await today_module.today(today_msg)
+
+        assert today_msg.replies, "Expected a reply from /today"
+        assert today_msg.replies[0].startswith("📋 *Today*"), today_msg.replies[0]
+
+    import asyncio
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- compute week start (Monday) when storing plan
- compute week start when fetching today's workout
- add regression test for /today handler

## Testing
- `PYTHONPATH=src pytest -q`
- `pre-commit run --files src/buddy_gym_bot/handlers/plan.py src/buddy_gym_bot/handlers/today.py tests/test_today_handler.py` *(fails: ssh: connect to host github.com port 22: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b8e592c8331bc5534af33e5c696