### PR TITLE
Use HTTPS for pre-commit repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
-  - repo: git@github.com:astral-sh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.8
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
-  - repo: git@github.com:RobertCraigie/pyright-python
+  - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.403
     hooks:
     - id: pyright
 
-  - repo: git@github.com:pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: end-of-file-fixer


### PR DESCRIPTION
## Summary
- switch pre-commit hook repositories from SSH to HTTPS URLs for broader accessibility

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a2d51c37c833190d3a12027763193