### PR TITLE
Fix JSON handling for stored workout plans

### DIFF
--- a/src/buddy_gym_bot/handlers/today.py
+++ b/src/buddy_gym_bot/handlers/today.py
@@ -1,5 +1,6 @@
 """Handler for the /today command."""
 
+import json
 import logging
 from datetime import date, timedelta
 
@@ -28,5 +29,9 @@ async def today(msg: Message):
     if not rec:
         return await msg.reply("No plan for today. Run /plan first.")
     plan = rec[0]
+    if isinstance(plan, str):
+        plan = json.loads(plan)
+    elif hasattr(plan, "data"):
+        plan = plan.data
     lines = [f"• {e['name']}: {e['sets']}x{e['reps']}" for e in plan]
     await msg.reply("📋 *Today*\n" + "\n".join(lines), parse_mode="Markdown")


### PR DESCRIPTION
## Summary
- serialize workout plans with Jsonb for psycopg connections to prevent `cannot adapt type 'dict'` errors
- decode plan payloads in /today handler when returned as strings or Json wrappers

## Testing
- `pre-commit run --files src/buddy_gym_bot/handlers/plan.py src/buddy_gym_bot/handlers/today.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa0b72bb483318e0f3d2d04157c21