### PR TITLE
Add web app form for logging workouts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/buddy_gym_bot/webapp *

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ primary_region = 'lax'
 [env]
   PLAN_DEFAULT_SPLIT = 'full_body'
   # USE_WEBHOOK = 'true'
+  WEBAPP_URL = 'https://buddy-gym-bot.fly.dev/webapp/'
 
 [[services]]
   protocol = 'tcp'

--- a/src/buddy_gym_bot/handlers/log.py
+++ b/src/buddy_gym_bot/handlers/log.py
@@ -5,9 +5,15 @@ import logging
 import re
 
 from aiogram import Router
-from aiogram.types import Message
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    WebAppInfo,
+)
 
 from buddy_gym_bot.db import get_conn
+from buddy_gym_bot.settings import settings
 
 router = Router()
 
@@ -27,7 +33,21 @@ async def log(msg: Message) -> None:
     m = PAT.search(text)
     if not m:
         logger.debug("Failed to parse log command: %s", text)
-        await msg.reply("Format: /log Bench 3x5 @ 60kg RPE7")
+        kb = None
+        if settings.WEBAPP_URL:
+            kb = InlineKeyboardMarkup(
+                inline_keyboard=[
+                    [
+                        InlineKeyboardButton(
+                            text="Open log form", web_app=WebAppInfo(url=settings.WEBAPP_URL)
+                        )
+                    ]
+                ]
+            )
+        await msg.reply(
+            "Format: /log Bench 3x5 @ 60kg RPE7",
+            reply_markup=kb,
+        )
         return
 
     # Guard from_user; channel posts etc. may not have it

--- a/src/buddy_gym_bot/main.py
+++ b/src/buddy_gym_bot/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import cast
 
 from aiogram import Bot, Dispatcher
@@ -11,6 +12,7 @@ from aiogram.enums import ParseMode
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
 from aiohttp import web
 
+from buddy_gym_bot.db import get_conn
 from buddy_gym_bot.handlers.ask import router as r_ask
 from buddy_gym_bot.handlers.log import router as r_log
 from buddy_gym_bot.handlers.plan import router as r_plan
@@ -27,6 +29,49 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def build_app(bot: Bot) -> web.Application:
+    """Create the auxiliary HTTP application."""
+
+    app = web.Application()
+
+    async def healthz(_: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/healthz", healthz)
+
+    # Serve lightweight logging web app
+    app.router.add_static(
+        "/webapp/",
+        path=str(Path(__file__).parent / "webapp"),
+    )
+
+    async def webapp_log(request: web.Request) -> web.Response:
+        data = await request.json()
+        uid = int(data.get("tg_user_id", 0))
+        exercise = (data.get("exercise") or "").title()
+        sets_i = int(data.get("sets", 0))
+        reps_i = int(data.get("reps", 0))
+        weight_f = float(data.get("weight", 0))
+        rpe_f = float(data.get("rpe", 0))
+
+        async with get_conn() as conn:
+            await conn.execute(
+                "insert into logs (tg_user_id, exercise, sets, reps, weight, rpe) "
+                "values (%s, %s, %s, %s, %s, %s)",
+                (uid, exercise, sets_i, reps_i, weight_f, rpe_f),
+            )
+
+        await bot.send_message(
+            uid,
+            f"✅ Logged: {exercise} {sets_i}x{reps_i} @ {weight_f:g} RPE{rpe_f:g}",
+        )
+        return web.json_response({"status": "ok"})
+
+    app.router.add_post("/webapp/log", webapp_log)
+
+    return app
+
+
 async def main() -> None:
     bot = Bot(
         token=settings.BOT_TOKEN,
@@ -37,14 +82,10 @@ async def main() -> None:
     for r in (r_start, r_plan, r_today, r_log, r_stats, r_ask):
         dp.include_router(r)
 
+    app = build_app(bot)
+
     if settings.USE_WEBHOOK:
         logger.info("Starting in webhook mode")
-        app = web.Application()
-
-        async def healthz(_: web.Request) -> web.Response:
-            return web.Response(text="ok")
-
-        app.router.add_get("/healthz", healthz)
 
         SimpleRequestHandler(dp, bot).register(app, path="/bot")
 
@@ -62,19 +103,25 @@ async def main() -> None:
         startup_list.append(on_startup)
 
         setup_application(app, dp, bot=bot)
+    else:
+        logger.info("Starting in polling mode")
 
-        runner = web.AppRunner(app)
-        await runner.setup()
-        site = web.TCPSite(runner, host="0.0.0.0", port=8080)
-        await site.start()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="0.0.0.0", port=8080)
+    await site.start()
+
+    if settings.USE_WEBHOOK:
         try:
             await asyncio.Event().wait()
         finally:
             await runner.cleanup()
     else:
-        logger.info("Starting in polling mode")
-        await bot.delete_webhook(drop_pending_updates=True)
-        await dp.start_polling(bot)
+        try:
+            await bot.delete_webhook(drop_pending_updates=True)
+            await dp.start_polling(bot)
+        finally:
+            await runner.cleanup()
 
 
 if __name__ == "__main__":

--- a/src/buddy_gym_bot/settings.py
+++ b/src/buddy_gym_bot/settings.py
@@ -25,6 +25,7 @@ class Settings:
     REDIS_URL: str
     USE_WEBHOOK: bool
     WEBHOOK_URL: str
+    WEBAPP_URL: str
     PLAN_DEFAULT_SPLIT: str
     ADMIN_CHAT_ID: int | None
 
@@ -40,6 +41,7 @@ class Settings:
             REDIS_URL=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
             USE_WEBHOOK=_to_bool(os.getenv("USE_WEBHOOK"), default=False),
             WEBHOOK_URL=os.getenv("WEBHOOK_URL", ""),
+            WEBAPP_URL=os.getenv("WEBAPP_URL", ""),
             PLAN_DEFAULT_SPLIT=os.getenv("PLAN_DEFAULT_SPLIT", "full_body"),
             ADMIN_CHAT_ID=(int(admin_id) if (admin_id := os.getenv("ADMIN_CHAT_ID")) else None),
         )

--- a/src/buddy_gym_bot/webapp/app.js
+++ b/src/buddy_gym_bot/webapp/app.js
@@ -1,0 +1,24 @@
+const tg = window.Telegram.WebApp;
+
+const form = document.getElementById("log-form");
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const data = {
+    tg_user_id: tg?.initDataUnsafe?.user?.id,
+    exercise: form.exercise.value,
+    sets: Number(form.sets.value),
+    reps: Number(form.reps.value),
+    weight: Number(form.weight.value),
+    rpe: Number(form.rpe.value) || 0,
+  };
+  try {
+    await fetch("/webapp/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    tg.close();
+  } catch (err) {
+    alert("Failed to log set");
+  }
+});

--- a/src/buddy_gym_bot/webapp/index.html
+++ b/src/buddy_gym_bot/webapp/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Log workout</title>
+</head>
+<body>
+  <h1>Log workout</h1>
+  <form id="log-form">
+    <label>Exercise <input name="exercise" required /></label><br />
+    <label>Sets <input name="sets" type="number" required /></label><br />
+    <label>Reps <input name="reps" type="number" required /></label><br />
+    <label>Weight <input name="weight" type="number" step="any" required /></label><br />
+    <label>RPE <input name="rpe" type="number" step="any" /></label><br />
+    <button type="submit">Log</button>
+  </form>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a lightweight `/webapp` form for logging sets
- accept form submissions via new `/webapp/log` endpoint that writes to the `logs` table and confirms to the user
- expose `WEBAPP_URL` setting and show a button in `/log` when text parsing fails
- always run the `/webapp` server, even in polling mode, so Fly health checks and mini-app requests succeed

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac938cdfc833181942b66c8c640e6