### PR TITLE
Enable webhook mode for Fly deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,8 @@ primary_region = 'lax'
 
 [env]
   PLAN_DEFAULT_SPLIT = 'full_body'
-  # USE_WEBHOOK = 'true'
+  USE_WEBHOOK = 'true'
+  WEBHOOK_URL = 'https://buddy-gym-bot.fly.dev/bot'
   WEBAPP_URL = 'https://buddy-gym-bot.fly.dev/webapp/'
 
 [[services]]


### PR DESCRIPTION
## Summary
- enable webhook mode in Fly config so app listens on port 8080
- set `WEBHOOK_URL` so Telegram can deliver updates via webhook

## Testing
- `uv run --extra dev pre-commit run --files fly.toml`


------
https://chatgpt.com/codex/tasks/task_e_689ad1b50a0c8331a98622c8549855c0