### PR TITLE
Serve webapp index page to avoid 403

### DIFF
--- a/src/buddy_gym_bot/main.py
+++ b/src/buddy_gym_bot/main.py
@@ -49,6 +49,11 @@ async def main() -> None:
         app.router.add_get("/healthz", healthz)
 
         # Serve lightweight logging web app
+        async def webapp_index(_: web.Request) -> web.FileResponse:
+            return web.FileResponse(Path(__file__).parent / "webapp" / "index.html")
+
+        app.router.add_get("/webapp/", webapp_index)
+
         app.router.add_static(
             "/webapp/",
             path=str(Path(__file__).parent / "webapp"),


### PR DESCRIPTION
## Summary
- Serve index.html for `/webapp/` requests to prevent 403 errors

## Testing
- `pre-commit run --files src/buddy_gym_bot/main.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad572e58883318ad6b4e9c96d4cb3