### PR TITLE
Improve scheduling and referral logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure src package is importable
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))

--- a/tests/test_referral.py
+++ b/tests/test_referral.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from buddy_gym_bot.db import repo
+
+
+@pytest.mark.asyncio
+async def test_referral_requires_sets() -> None:
+    await repo.init_db()
+    host = await repo.upsert_user(1, "host", "en")
+    token = await repo.ensure_referral_token(host.id)
+    await repo.record_referral_click(2, token)
+
+    ok = await repo.fulfil_referral_for_invitee(2)
+    assert ok is False
+
+    invitee = await repo.upsert_user(2, "inv", "en")
+    sess = await repo.start_session(invitee.id)
+    await repo.append_set(sess.id, "bench", 100, 5, None)
+
+    ok2 = await repo.fulfil_referral_for_invitee(2)
+    assert ok2 is True

--- a/tests/test_schedule_utils.py
+++ b/tests/test_schedule_utils.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from buddy_gym_bot.bot.main import _next_datetime_for
+
+
+def test_next_datetime_valid() -> None:
+    dt = _next_datetime_for("Mon", "12:00", "UTC")
+    assert dt.weekday() == 0
+
+
+def test_next_datetime_invalid_weekday() -> None:
+    with pytest.raises(ValueError):
+        _next_datetime_for("Funday", "12:00", "UTC")
+
+
+def test_next_datetime_invalid_time() -> None:
+    with pytest.raises(ValueError):
+        _next_datetime_for("Mon", "24:61", "UTC")


### PR DESCRIPTION
## Summary
- avoid duplicate reminder jobs and validate weekday/time parsing
- handle OpenAI failures and malformed JSON gracefully
- verify workout activity before fulfilling referrals and validate share endpoint session IDs
- send admin logs asynchronously and add initial unit tests

## Testing
- `ruff check src/buddy_gym_bot/bot/main.py src/buddy_gym_bot/bot/openai_scheduling.py src/buddy_gym_bot/db/repo.py src/buddy_gym_bot/server/routes/share.py src/buddy_gym_bot/logging_setup.py tests/test_schedule_utils.py tests/test_referral.py`
- `pytest tests/test_schedule_utils.py tests/test_referral.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d9222162c83318efa3f76906bccfa