### PR TITLE
Use Telegram webhooks

### DIFF
--- a/src/buddy_gym_bot/config.py
+++ b/src/buddy_gym_bot/config.py
@@ -39,6 +39,11 @@ class Config(BaseSettings):
     DATABASE_URL: str = Field(..., description="Database URL")
     OPENAI_API_KEY: str | None = Field(None, description="OpenAI API key")
     WEBAPP_URL: str = Field("https://buddy-gym-bot.fly.dev/webapp/", description="Webapp URL")
+    USE_WEBHOOK: bool = Field(
+        default_factory=lambda: _bool("USE_WEBHOOK", False),
+        description="Use webhook mode instead of polling",
+    )
+    WEBHOOK_URL: str | None = Field(None, description="Public URL for Telegram webhook")
 
     EXERCISEDB_BASE_URL: str = Field(
         "https://exercisedb.dev/api/v1", description="ExerciseDB base URL"


### PR DESCRIPTION
## Summary
- add `USE_WEBHOOK` and `WEBHOOK_URL` settings
- disable polling when webhooks are enabled
- handle Telegram updates via FastAPI `/bot` endpoint

## Testing
- `uv run --with pre-commit pre-commit run --files src/buddy_gym_bot/config.py src/buddy_gym_bot/bot/main.py src/buddy_gym_bot/server/main.py`
- `uv run --with pytest --with pytest-asyncio python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9f5d4b088331917c3aebc1563ade