### PR TITLE
Support async SQLite URLs

### DIFF
--- a/src/buddy_gym_bot/config.py
+++ b/src/buddy_gym_bot/config.py
@@ -17,7 +17,10 @@ def _bool(name: str, default: bool) -> bool:
 
 def _norm_db_url(url: str | None) -> str | None:
     """
-    Normalize database URL to use asyncpg driver for SQLAlchemy.
+    Normalize database URL to use async drivers for SQLAlchemy.
+
+    Ensures ``postgres`` URLs use ``asyncpg`` and plain ``sqlite`` URLs use
+    ``aiosqlite``. URLs already specifying an async driver are returned as-is.
     """
     if not url:
         return None
@@ -25,6 +28,8 @@ def _norm_db_url(url: str | None) -> str | None:
         url = "postgresql+asyncpg://" + url[len("postgres://") :]
     if url.startswith("postgresql://"):
         url = "postgresql+asyncpg://" + url[len("postgresql://") :]
+    if url.startswith("sqlite://"):
+        url = "sqlite+aiosqlite://" + url[len("sqlite://") :]
     return url
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+import os
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from buddy_gym_bot.config import _norm_db_url
+
+
+def test_norm_db_url_sqlite_to_aiosqlite() -> None:
+    assert _norm_db_url("sqlite:///test.db") == "sqlite+aiosqlite:///test.db"
+    assert _norm_db_url("sqlite:///:memory:") == "sqlite+aiosqlite:///:memory:"
+    # already using aiosqlite should stay untouched
+    assert _norm_db_url("sqlite+aiosqlite:///test.db") == "sqlite+aiosqlite:///test.db"


### PR DESCRIPTION
## Summary
- normalize `sqlite://` URLs to use `sqlite+aiosqlite://`
- add tests for SQLite URL normalization

## Testing
- `pre-commit run --files src/buddy_gym_bot/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da2ff50dc8331ad32cb65a4ad9bba