### PR TITLE
chore: migrate to psycopg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
   "httpx",
   "sqlalchemy",
   "Pillow",
-  "asyncpg",
   "aiosqlite",
   "Babel",
   "apscheduler",

--- a/src/buddy_gym_bot/config.py
+++ b/src/buddy_gym_bot/config.py
@@ -19,15 +19,15 @@ def _norm_db_url(url: str | None) -> str | None:
     """
     Normalize database URL to use async drivers for SQLAlchemy.
 
-    Ensures ``postgres`` URLs use ``asyncpg`` and plain ``sqlite`` URLs use
+    Ensures ``postgres`` URLs use ``psycopg`` and plain ``sqlite`` URLs use
     ``aiosqlite``. URLs already specifying an async driver are returned as-is.
     """
     if not url:
         return None
     if url.startswith("postgres://"):
-        url = "postgresql+asyncpg://" + url[len("postgres://") :]
+        url = "postgresql+psycopg://" + url[len("postgres://") :]
     if url.startswith("postgresql://"):
-        url = "postgresql+asyncpg://" + url[len("postgresql://") :]
+        url = "postgresql+psycopg://" + url[len("postgresql://") :]
     if url.startswith("sqlite://"):
         url = "sqlite+aiosqlite://" + url[len("sqlite://") :]
     return url

--- a/tests/test_repo_init_db.py
+++ b/tests/test_repo_init_db.py
@@ -14,7 +14,7 @@ async def test_init_db_respects_ssl_disable(monkeypatch):
     repo._engine = None
     repo._session = None
     original_url = repo.SETTINGS.DATABASE_URL
-    repo.SETTINGS.DATABASE_URL = "postgresql+asyncpg://user:pass@localhost/db?sslmode=disable"
+    repo.SETTINGS.DATABASE_URL = "postgresql+psycopg://user:pass@localhost/db?sslmode=disable"
 
     captured: dict = {}
 
@@ -46,5 +46,5 @@ async def test_init_db_respects_ssl_disable(monkeypatch):
         repo._engine = None
         repo._session = None
 
-    assert captured["connect_args"]["ssl"] is False
-    assert captured["connect_args"]["statement_cache_size"] == 0
+    assert captured["connect_args"]["sslmode"] == "disable"
+    assert "statement_cache_size" not in captured["connect_args"]

--- a/uv.lock
+++ b/uv.lock
@@ -127,22 +127,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncpg"
-version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/4c/7c991e080e106d854809030d8584e15b2e996e26f16aee6d757e387bc17d/asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851", size = 957746, upload-time = "2024-10-20T00:30:41.127Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/22/e20602e1218dc07692acf70d5b902be820168d6282e69ef0d3cb920dc36f/asyncpg-0.30.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05b185ebb8083c8568ea8a40e896d5f7af4b8554b64d7719c0eaa1eb5a5c3a70", size = 670373, upload-time = "2024-10-20T00:29:55.165Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b3/0cf269a9d647852a95c06eb00b815d0b95a4eb4b55aa2d6ba680971733b9/asyncpg-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c47806b1a8cbb0a0db896f4cd34d89942effe353a5035c62734ab13b9f938da3", size = 634745, upload-time = "2024-10-20T00:29:57.14Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/6d/a4f31bf358ce8491d2a31bfe0d7bcf25269e80481e49de4d8616c4295a34/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b6fde867a74e8c76c71e2f64f80c64c0f3163e687f1763cfaf21633ec24ec33", size = 3512103, upload-time = "2024-10-20T00:29:58.499Z" },
-    { url = "https://files.pythonhosted.org/packages/96/19/139227a6e67f407b9c386cb594d9628c6c78c9024f26df87c912fabd4368/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46973045b567972128a27d40001124fbc821c87a6cade040cfcd4fa8a30bcdc4", size = 3592471, upload-time = "2024-10-20T00:30:00.354Z" },
-    { url = "https://files.pythonhosted.org/packages/67/e4/ab3ca38f628f53f0fd28d3ff20edff1c975dd1cb22482e0061916b4b9a74/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9110df111cabc2ed81aad2f35394a00cadf4f2e0635603db6ebbd0fc896f46a4", size = 3496253, upload-time = "2024-10-20T00:30:02.794Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5f/0bf65511d4eeac3a1f41c54034a492515a707c6edbc642174ae79034d3ba/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04ff0785ae7eed6cc138e73fc67b8e51d54ee7a3ce9b63666ce55a0bf095f7ba", size = 3662720, upload-time = "2024-10-20T00:30:04.501Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/31/1513d5a6412b98052c3ed9158d783b1e09d0910f51fbe0e05f56cc370bc4/asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590", size = 560404, upload-time = "2024-10-20T00:30:06.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/a4/cec76b3389c4c5ff66301cd100fe88c318563ec8a520e0b2e792b5b84972/asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e", size = 621623, upload-time = "2024-10-20T00:30:09.024Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -168,7 +152,6 @@ dependencies = [
     { name = "aiogram" },
     { name = "aiosqlite" },
     { name = "apscheduler" },
-    { name = "asyncpg" },
     { name = "babel" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -198,7 +181,6 @@ requires-dist = [
     { name = "aiogram", specifier = "==3.21.0" },
     { name = "aiosqlite" },
     { name = "apscheduler" },
-    { name = "asyncpg" },
     { name = "babel" },
     { name = "fastapi" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- switch PostgreSQL driver from asyncpg to psycopg
- handle sslmode for psycopg connections
- drop asyncpg dependency and update test for new driver

## Testing
- `uv run --extra dev --extra test pre-commit run --files pyproject.toml uv.lock src/buddy_gym_bot/config.py src/buddy_gym_bot/db/repo.py tests/test_repo_init_db.py`
- `uv run --extra test pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da768fc548331902ef5625d6bd690