### PR TITLE
Rename Telegram ID column to tg_id

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,6 +1,6 @@
 create table if not exists users (
   id bigserial primary key,
-  tg_user_id bigint unique not null,
+  tg_id bigint unique not null,
   created_at timestamptz default now(),
   goal text,
   experience text,
@@ -11,7 +11,7 @@ create table if not exists users (
 
 create table if not exists workouts (
   id bigserial primary key,
-  tg_user_id bigint not null,
+  tg_id bigint not null,
   day_of_week int not null,
   plan jsonb not null,
   week_start date not null
@@ -19,7 +19,7 @@ create table if not exists workouts (
 
 create table if not exists logs (
   id bigserial primary key,
-  tg_user_id bigint not null,
+  tg_id bigint not null,
   ts timestamptz default now(),
   exercise text not null,
   sets int,
@@ -28,5 +28,5 @@ create table if not exists logs (
   rpe numeric
 );
 
-create index if not exists idx_workouts_user_week on workouts(tg_user_id, week_start);
-create index if not exists idx_logs_user_ts on logs(tg_user_id, ts);
+create index if not exists idx_workouts_user_week on workouts(tg_id, week_start);
+create index if not exists idx_logs_user_ts on logs(tg_id, ts);

--- a/migrations/002_rename_tg_id.sql
+++ b/migrations/002_rename_tg_id.sql
@@ -1,0 +1,3 @@
+alter table if exists users rename column tg_user_id to tg_id;
+alter table if exists workouts rename column tg_user_id to tg_id;
+alter table if exists logs rename column tg_user_id to tg_id;


### PR DESCRIPTION
## Summary
- use consistent `tg_id` column name in initial schema
- add migration renaming existing `tg_user_id` columns

## Testing
- `uv run pytest`
- `uv run pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689e3004487c8331832378037496ce2f