### PR TITLE
Handle legacy tg_user_id column during DB init

### DIFF
--- a/src/buddy_gym_bot/db/repo.py
+++ b/src/buddy_gym_bot/db/repo.py
@@ -68,6 +68,13 @@ async def init_db() -> None:
     )
     _session = async_sessionmaker(_engine, expire_on_commit=False)
     async with _engine.begin() as conn:
+        for table in ("users", "workouts", "logs"):
+            try:
+                await conn.exec_driver_sql(
+                    f"ALTER TABLE {table} RENAME COLUMN tg_user_id TO tg_id"
+                )
+            except Exception:
+                pass
         await conn.run_sync(Base.metadata.create_all)
 
 


### PR DESCRIPTION
## Summary
- rename old tg_user_id columns to tg_id on startup to avoid missing column errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e3597388083319fa5b97cbf28f3bc