### PR TITLE
Fix shutdown error and add emoji greeting

### DIFF
--- a/src/buddy_gym_bot/bot/main.py
+++ b/src/buddy_gym_bot/bot/main.py
@@ -21,7 +21,7 @@ from ..logging_setup import setup_logging
 from .commands_labels import apply_localized_commands
 from .openai_scheduling import generate_schedule
 from .parsers import TRACK_RE
-from .utils import webapp_button
+from .utils import wave_hello, webapp_button
 
 router = Router()
 scheduler = AsyncIOScheduler()
@@ -53,8 +53,10 @@ async def _handle_start(message: Message) -> None:
             except Exception:
                 logging.exception("record_referral_click failed")
     kb = webapp_button(SETTINGS.WEBAPP_URL, "Open BuddyGym")
+    greeting = wave_hello(message.from_user.first_name or "Athlete")
     await message.answer(
-        "Welcome to BuddyGym! Track your workouts and get reminders.", reply_markup=kb
+        f"{greeting} Welcome to BuddyGym! Track your workouts and get reminders.",
+        reply_markup=kb,
     )
 
 

--- a/src/buddy_gym_bot/bot/utils.py
+++ b/src/buddy_gym_bot/bot/utils.py
@@ -8,3 +8,8 @@ def webapp_button(url: str, text: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[[InlineKeyboardButton(text=text, web_app=WebAppInfo(url=url))]]
     )
+
+
+def wave_hello(name: str) -> str:
+    """Return a friendly greeting with a wave emoji."""
+    return f"👋 Hello, {name}!"

--- a/src/buddy_gym_bot/server/main.py
+++ b/src/buddy_gym_bot/server/main.py
@@ -81,7 +81,7 @@ async def _startup() -> None:
 async def _shutdown() -> None:
     """FastAPI shutdown: clean up bot resources."""
     await bot.delete_webhook()
-    await dp.emit_shutdown(bot)
+    await dp.emit_shutdown()
     await bot.session.close()
 
 

--- a/tests/test_wave_hello.py
+++ b/tests/test_wave_hello.py
@@ -1,0 +1,7 @@
+from buddy_gym_bot.bot.utils import wave_hello
+
+
+def test_wave_hello_contains_emoji():
+    message = wave_hello("Alex")
+    assert "👋" in message
+    assert "Alex" in message


### PR DESCRIPTION
## Summary
- fix dispatcher shutdown by calling `emit_shutdown` without `bot`
- add `wave_hello` helper using a non-BMP emoji and integrate into `/start`
- test greeting helper

## Testing
- `pre-commit run --files src/buddy_gym_bot/bot/utils.py src/buddy_gym_bot/bot/main.py src/buddy_gym_bot/server/main.py tests/test_wave_hello.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e3e8b68f48331a2ced226955ba042