### PR TITLE
Run SQL migrations at startup

### DIFF
--- a/tests/test_repo_init_db.py
+++ b/tests/test_repo_init_db.py
@@ -48,3 +48,45 @@ async def test_init_db_respects_ssl_disable(monkeypatch):
 
     assert captured["connect_args"]["sslmode"] == "disable"
     assert "statement_cache_size" not in captured["connect_args"]
+
+
+@pytest.mark.asyncio
+async def test_init_db_runs_migrations(monkeypatch):
+    repo._engine = None
+    repo._session = None
+    original_url = repo.SETTINGS.DATABASE_URL
+    repo.SETTINGS.DATABASE_URL = "postgresql+psycopg://user:pass@localhost/db"
+
+    executed: list[str] = []
+
+    class DummyConn:
+        def __init__(self):
+            self.dialect = type("D", (), {"name": "postgresql"})()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def run_sync(self, fn):
+            return None
+
+        async def exec_driver_sql(self, sql):
+            executed.append(sql)
+
+    class DummyEngine:
+        def begin(self):
+            return DummyConn()
+
+    monkeypatch.setattr(repo, "create_async_engine", lambda *a, **k: DummyEngine())
+    monkeypatch.setattr(repo, "async_sessionmaker", lambda *a, **k: None)
+
+    try:
+        await repo.init_db()
+    finally:
+        repo.SETTINGS.DATABASE_URL = original_url
+        repo._engine = None
+        repo._session = None
+
+    assert any("handle" in sql for sql in executed)


### PR DESCRIPTION
## Summary
- execute SQL migration files during database initialization
- add regression test to verify migrations run

## Testing
- `uv run pre-commit run --files src/buddy_gym_bot/db/repo.py tests/test_repo_init_db.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4a6af6608331b43906e072198277