### PR TITLE
fix: serve webapp assets under subpath

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Build the webapp to be served from /webapp/
 export default defineConfig({
+  base: '/webapp/',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- ensure built webapp assets use /webapp base path

## Testing
- `uvx pre-commit run --files webapp/vite.config.js`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e56995e1c83318f52e895e67c6b1f