### PR TITLE
Implement DB close helper and integrate with shutdown

### DIFF
--- a/src/buddy_gym_bot/db/__init__.py
+++ b/src/buddy_gym_bot/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities exposed for external runtimes."""
+
+from .repo import close_db, get_session, init_db
+
+__all__ = ["close_db", "get_session", "init_db"]

--- a/src/buddy_gym_bot/db/repo.py
+++ b/src/buddy_gym_bot/db/repo.py
@@ -131,6 +131,16 @@ def get_session() -> async_sessionmaker[AsyncSession]:
     return _session
 
 
+async def close_db() -> None:
+    """Dispose of the database engine and reset session state."""
+
+    global _engine, _session
+    if _engine:
+        await _engine.dispose()
+    _engine = None
+    _session = None
+
+
 async def upsert_user(tg_id: int, handle: str | None, lang: str | None) -> User:
     """
     Insert or update a user by Telegram ID. Updates handle/lang if changed.

--- a/src/buddy_gym_bot/server/main.py
+++ b/src/buddy_gym_bot/server/main.py
@@ -21,6 +21,7 @@ from fastapi.staticfiles import StaticFiles
 from ..bot.main import on_startup as bot_on_startup
 from ..bot.main import router as tg_router
 from ..config import SETTINGS
+from ..db import close_db
 from .routes.exercises import router as r_exercises
 from .routes.share import router as r_share
 from .routes.workout import router as r_workout
@@ -82,6 +83,7 @@ async def _shutdown() -> None:
     """FastAPI shutdown: clean up bot resources."""
     await bot.delete_webhook()
     await dp.emit_shutdown()
+    await close_db()
     await bot.session.close()
 
 


### PR DESCRIPTION
## Summary
- add `close_db` to dispose SQLAlchemy engine and reset session state
- export `close_db` from db package
- close database during FastAPI shutdown sequence

## Testing
- `pre-commit run --files src/buddy_gym_bot/db/repo.py src/buddy_gym_bot/server/main.py src/buddy_gym_bot/db/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa9d69bd88331af3cadaeb23f5781