### PR TITLE
Validate weight and reps input in track command

### DIFF
--- a/src/buddy_gym_bot/bot/main.py
+++ b/src/buddy_gym_bot/bot/main.py
@@ -76,6 +76,9 @@ async def cmd_track(message: Message) -> None:
     ex = m.group("ex")
     w = float(m.group("w"))
     r = int(m.group("r"))
+    if w <= 0 or r <= 0:
+        await message.reply("Weight and reps must be greater than zero.")
+        return
     rpe = m.group("rpe")
     rpe_val = float(rpe) if rpe else None
     user = await repo.upsert_user(

--- a/tests/test_cmd_track_validation.py
+++ b/tests/test_cmd_track_validation.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from buddy_gym_bot.bot.main import cmd_track
+
+
+class DummyUser:
+    def __init__(self, id: int = 1, username: str = "tester", language_code: str = "en"):
+        self.id = id
+        self.username = username
+        self.language_code = language_code
+
+
+class DummyMessage:
+    def __init__(self, text: str):
+        self.text = text
+        self.from_user = DummyUser()
+        self.replies: list[str] = []
+
+    async def reply(self, text: str, parse_mode: str | None = None) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_cmd_track_negative_weight() -> None:
+    msg = DummyMessage("/track bench -100x5")
+    await cmd_track(msg)
+    assert msg.replies and msg.replies[0].startswith("Usage: /track")
+
+
+@pytest.mark.asyncio
+async def test_cmd_track_negative_reps() -> None:
+    msg = DummyMessage("/track bench 100x-5")
+    await cmd_track(msg)
+    assert msg.replies and msg.replies[0].startswith("Usage: /track")
+
+
+@pytest.mark.asyncio
+async def test_cmd_track_zero_weight() -> None:
+    msg = DummyMessage("/track bench 0x5")
+    await cmd_track(msg)
+    assert msg.replies == ["Weight and reps must be greater than zero."]
+
+
+@pytest.mark.asyncio
+async def test_cmd_track_zero_reps() -> None:
+    msg = DummyMessage("/track bench 100x0")
+    await cmd_track(msg)
+    assert msg.replies == ["Weight and reps must be greater than zero."]


### PR DESCRIPTION
## Summary
- ensure `/track` rejects non-positive weight or reps
- add tests for negative and zero weight and reps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fabb9a4048331879e99d17591821b