### PR TITLE
Re-raise startup failures

### DIFF
--- a/src/buddy_gym_bot/server/main.py
+++ b/src/buddy_gym_bot/server/main.py
@@ -76,6 +76,7 @@ async def _startup() -> None:
             await bot.set_webhook(SETTINGS.WEBHOOK_URL, drop_pending_updates=True)
     except Exception:
         logging.exception("Startup failed")
+        raise
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- ensure FastAPI startup raises errors after logging so initialization failures stop the process

## Testing
- `pre-commit run --files src/buddy_gym_bot/server/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a02f7619d08331ac30d28567026ca6