### PR TITLE
Display schedule in /schedule response

### DIFF
--- a/src/buddy_gym_bot/bot/main.py
+++ b/src/buddy_gym_bot/bot/main.py
@@ -96,6 +96,27 @@ async def cmd_track(message: Message) -> None:
     await message.answer(f"Logged: {ex} {w}x{r}" + (f" RPE{rpe_val:g}" if rpe_val else ""))
 
 
+def render_plan_message(plan: dict) -> str:
+    """Render a human-readable summary of the workout plan."""
+    lines: list[str] = ["Plan created ✅ I'll remind you before workouts."]
+    for day in plan.get("days", []):
+        weekday = day.get("weekday", "?")
+        time = day.get("time")
+        focus = day.get("focus")
+        header = weekday
+        if time:
+            header += f" {time}"
+        if focus:
+            header += f" — {focus}"
+        lines.append(header)
+        for ex in day.get("exercises", []):
+            name = ex.get("name", "exercise")
+            sets = ", ".join(s.get("reps", "") for s in ex.get("sets", []))
+            lines.append(f"• {name}: {sets}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
 @router.message(Command("schedule"))
 async def cmd_schedule(message: Message) -> None:
     """Handle /schedule command to generate a workout plan and schedule reminders."""
@@ -129,7 +150,7 @@ async def cmd_schedule(message: Message) -> None:
         except Exception:
             logging.exception("Scheduling reminders failed")
 
-    await message.answer("Plan created ✅ I'll remind you before workouts.")
+    await message.answer(render_plan_message(plan))
 
 
 async def schedule_plan_reminders(bot: Bot, chat_id: int, plan: dict) -> None:

--- a/tests/test_plan_render.py
+++ b/tests/test_plan_render.py
@@ -1,0 +1,28 @@
+from buddy_gym_bot.bot.main import render_plan_message
+
+
+def test_render_plan_message():
+    plan = {
+        "days": [
+            {
+                "weekday": "Mon",
+                "time": "18:00",
+                "focus": "Upper",
+                "exercises": [
+                    {"name": "Bench", "sets": [{"reps": "3x5"}]},
+                    {"name": "Row", "sets": [{"reps": "3x8"}]},
+                ],
+            },
+            {
+                "weekday": "Wed",
+                "time": "18:00",
+                "focus": "Lower",
+                "exercises": [{"name": "Squat", "sets": [{"reps": "3x5"}]}],
+            },
+        ]
+    }
+    text = render_plan_message(plan)
+    assert "Mon 18:00 — Upper" in text
+    assert "• Bench: 3x5" in text
+    assert "Wed 18:00 — Lower" in text
+    assert "• Squat: 3x5" in text


### PR DESCRIPTION
## Summary
- Format workout plan into readable schedule and send it to users on /schedule
- Test plan rendering helper

## Testing
- `make test`
- `make precommit`


------
https://chatgpt.com/codex/tasks/task_e_68a0357e154483318971f0c6b237d80d